### PR TITLE
Bump build number to re-run pipelines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,5 @@ bld.bat text eol=crlf
 /README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
+pixi.toml linguist-generated=true
 shippable.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: v1.7.3-rc1
 
 build:
-  number: 2
+  number: 3
 
 # About git-lfs:  There are files stored in LFS in the
 # tracktable-docs and tracktable-data repositories.  These


### PR DESCRIPTION
The Windows runners hung and timed out on the last PR.  This commit bumps up the build number to re-run them and makes no other changes.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
