### PR TITLE
Build from source with notebooks

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/sandialabs/tracktable
-  git_rev: v1.7.3-rc1
+  url: https://github.com/sandialabs/tracktable/archive/refs/tags/v1.7.3.tar.gz
+  sha256: cffd0896ce751ed097c57c893734fa6fb56d116c2bfef236145b011f482cd1e4
 
 build:
-  number: 3
+  number: 4
 
 # About git-lfs:  There are files stored in LFS in the
 # tracktable-docs and tracktable-data repositories.  These

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,19 @@ package:
   version: {{ version }}
 
 source:
+
+  # Source code proper
   url: https://github.com/sandialabs/tracktable/archive/refs/tags/v1.7.3.tar.gz
   sha256: cffd0896ce751ed097c57c893734fa6fb56d116c2bfef236145b011f482cd1e4
 
+  # Documentation so we can clean and pull in notebooks
+  url: https://github.com/sandialabs/tracktable-docs/archive/refs/tags/v1.7.3.tar.gz
+  sha256: 14aef19e58e3db5b31275afe7e6f45a2341dd706c945523b54673a5ca14ceeb7
+    folder: tracktable-docs
+
+
 build:
-  number: 4
+  number: 5
 
 # About git-lfs:  There are files stored in LFS in the
 # tracktable-docs and tracktable-data repositories.  These

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: v1.7.3-rc1
 
 build:
-  number: 2
+  number: 3
 
 # About git-lfs:  There are files stored in LFS in the
 # tracktable-docs and tracktable-data repositories.  These


### PR DESCRIPTION
Change the recipe to build from source tarballs instead of the repository.

We also need to pull in the tracktable-docs tarball to get the notebooks for bundling.  

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
